### PR TITLE
Remove 'years active' count from Lobbyist and Org detail views

### DIFF
--- a/camp_fin/templates/camp_fin/lobbyist-detail.html
+++ b/camp_fin/templates/camp_fin/lobbyist-detail.html
@@ -43,15 +43,6 @@
             </h2>
             <table class="table table-striped">
                 <tbody>
-                    <tr>
-                        <td>
-                            <i class="fa fa-fw fa-clock-o"></i>
-                            Years active
-                        </td>
-                        <td class="text-right">
-                            {{ lobbyist.years_active|format_years }}
-                        </td>
-                    </tr>
                     {% if last_year_employed %}
                         <tr>
                             <td>

--- a/camp_fin/templates/camp_fin/organization-detail.html
+++ b/camp_fin/templates/camp_fin/organization-detail.html
@@ -46,15 +46,6 @@
                     <tbody>
                         <tr>
                             <td>
-                                <i class="fa fa-fw fa-clock-o"></i>
-                                Years active
-                            </td>
-                            <td class="text-right">
-                                {{ organization.years_active|format_years }}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
                                 <i class="fa fa-fw fa-building"></i>
                                 Address
                             </td>


### PR DESCRIPTION
## Overview

Marjorie found the 'years active' count to be confusing because it only considers employer data (which goes back to 2013) rather than incorporating the first and last contribution/expenditures (which
go back to 2011). In the future we may want to update this count to consider first and last contributions/expenditures in order to report the active years for Lobbyists/Orgs, but for now simply remove the count from the detail views.

Also, update the source data for the transactions table.