### PR TITLE
bumped requirements based on dependabot and failed psycopg2 install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.29
 psycopg2==2.8.6
 SQLAlchemy==1.3.0
 django-bootstrap-pagination==1.6.2
-djangorestframework==3.9.1
+djangorestframework==3.4.6
 django-pdb==0.6.1
 markdown==2.6.6
 django-filter==0.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Django==1.10.8
-psycopg2==2.7.7
-SQLAlchemy==1.0.14
+Django==1.11.29
+psycopg2==2.8.6
+SQLAlchemy==1.3.0
 django-bootstrap-pagination==1.6.2
-djangorestframework==3.4.6
+djangorestframework==3.9.1
 django-pdb==0.6.1
 markdown==2.6.6
 django-filter==0.14.0
@@ -10,7 +10,7 @@ openpyxl==2.6.4
 gunicorn==19.6.0
 pytz==2016.6.1
 django-ckeditor==5.1.1
-Pillow==3.3.1
+Pillow==7.1.0
 djangorestframework-csv==1.4.1
 raven==6.10.0
 python-dateutil==2.8.1


### PR DESCRIPTION
Bump requirements 

Closes #169 
Connects #168 

Also resolves a failed install of `psycopg2` 