### PR TITLE
Remove lobbyist data from the site (Revert me when adding new lobbyist data)

### DIFF
--- a/camp_fin/templates/base.html
+++ b/camp_fin/templates/base.html
@@ -90,9 +90,6 @@
                         </ul>
                     </li>
                     <li>
-                        <a href="{% url 'lobbyist-portal' %}"><i class='fa fa-university'></i> Lobbyists</a>
-                    </li>
-                    <li>
                         <a href="{% url 'downloads' %}"><i class='fa fa-download'></i> Data downloads</a>
                     </li>
                     <li>

--- a/camp_fin/templates/camp_fin/search.html
+++ b/camp_fin/templates/camp_fin/search.html
@@ -33,15 +33,6 @@
                         <label data-title='Expenditures' data-content='Any person or organization who was given money by a political committee'>
                             <input type="checkbox" name="table_name" value="expenditure" {% if 'expenditure' in table_name %}checked='checked'{% endif %}> Expenditures by committees
                         </label>
-                        <label data-title='Lobbyists' data-content='Any person who has registered as a lobbyist'>
-                            <input type="checkbox" name="table_name" value="lobbyist" {% if 'lobbyist' in table_name %}checked='checked'{% endif %}> Lobbyists
-                        </label>
-                        <label data-title='Lobbyist employers' data-content='Any organization that has paid registered lobbyists'>
-                            <input type="checkbox" name="table_name" value="organization" {% if 'organization' in table_name %}checked='checked'{% endif %}> Lobbyist employers
-                        </label>
-                        <label data-title='Lobbyist spending' data-content='Spending that lobbyists have reported'>
-                            <input type="checkbox" name="table_name" value="lobbyisttransaction" {% if 'lobbyisttransaction' in table_name %}checked='checked'{% endif %}> Lobbyist spending
-                        </label>
                     </div>
                 </form>
             </div>
@@ -116,49 +107,6 @@
                         <th class='hidden-xs hidden-sm'>Date</th>
                         <th>Amount</th>
                         <th class='hidden-xs hidden-sm'>Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-            </table>
-            <hr />
-        </div>
-        <div id="lobbyist-search-results" class="col-md-12" style="display:none;">
-            <h3>Lobbyists <small></small></h3>
-            <table class="table table-hover datatable-table" id="lobbyist-table">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                    </tr>
-                </thead>
-                <tbody>
-            </table>
-            <hr />
-        </div>
-        <div id="organization-search-results" class="col-md-12" style="display:none;">
-            <h3>Lobbyist employers <small></small></h3>
-            <table class="table table-hover datatable-table" id="organization-table">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Address</th>
-                    </tr>
-                </thead>
-                <tbody>
-            </table>
-            <hr />
-        </div>
-        <div id="lobbyisttransaction-search-results" class="col-md-12" style="display:none;">
-            <h3>Lobbyist spending <small></small></h3>
-            <table class="table table-hover datatable-table" id="lobbyisttransaction-table">
-                <thead>
-                    <tr>
-                        <th>Lobbyist</th>
-                        <th>Type</th>
-                        <th>Paid to</th>
-                        <th>Amount</th>
-                        <th>Beneficiary</th>
-                        <th>Description</th>
-                        <th>Date</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/camp_fin/templates/index.html
+++ b/camp_fin/templates/index.html
@@ -24,9 +24,7 @@ Keep an eye on money in New Mexico politics
                     <input type='hidden' name='table_name' value='treasurer' />
                     <input type='hidden' name='table_name' value='contribution' />
                     <input type='hidden' name='table_name' value='expenditure' />
-                    <input type='hidden' name='table_name' value='lobbyist' />
                     <input type='hidden' name='table_name' value='organization' />
-                    <input type='hidden' name='table_name' value='lobbyisttransaction' />
                     <span class="input-group-btn">
                         <button class="btn btn-default" type="submit"><i class='fa fa-search'></i> <span class='hidden-sm hidden-xs'>Search</span></button>
                     </span>

--- a/pages/templates/downloads.html
+++ b/pages/templates/downloads.html
@@ -64,82 +64,9 @@
                     {% include 'camp_fin/widgets/calendar-form.html' %}
                 {% endwith %}
                 <div class="col-xs-12">
-                    <br/>
+                    <br/><br />
                 </div>
             </div>
-
-            <br />
-            <h3>
-                <i class="fa fa-fw fa-university"></i>
-                Lobbyists and lobbyist employers
-            </h3>
-            <br/>
-
-            <div class="row">
-                <h4 class="col-xs-12">
-                    <i class="fa fa-fw fa-usd"></i>
-                    Cash donations
-                </h4>
-                {% with action='/api/bulk/lobbyist-contributions/' icon='fa fa-fw fa-download' title='Cash donations' from_id='from5' to_id='to5' %}
-                    {% include 'camp_fin/widgets/calendar-form.html' %}
-                {% endwith %}
-                <div class="col-xs-12">
-                    <br/>
-                </div>
-            </div>
-
-            <div class="row">
-                <h4 class="col-xs-12">
-                    <i class="fa fa-fw fa-gift"></i>
-                    Expenditures and gifts
-                </h4>
-                {% with action='/api/bulk/lobbyist-expenditures/' icon='fa fa-fw fa-download' title='Expenditures and gifts' from_id='from6' to_id='to6' %}
-                    {% include 'camp_fin/widgets/calendar-form.html' %}
-                {% endwith %}
-                <div class="col-xs-12">
-                    <br/>
-                </div>
-            </div>
-
-            <div class="row">
-                <h4 class="col-xs-12">
-                    <i class="fa fa-fw fa-user"></i>
-                    Lobbyists
-                </h4>
-                {% with action='/api/bulk/lobbyists/' icon='fa fa-fw fa-download' title='Lobbyists' from_id='from7' to_id='to7' %}
-                    {% include 'camp_fin/widgets/calendar-form.html' %}
-                {% endwith %}
-                <div class="col-xs-12">
-                    <br/>
-                </div>
-            </div>
-
-            <div class="row">
-                <h4 class="col-xs-12">
-                    <i class="fa fa-fw fa-users"></i>
-                    Lobbyist employers
-                </h4>
-                {% with action='/api/bulk/employers/' icon='fa fa-fw fa-download' title='Lobbyist employers' from_id='from8' to_id='to8' %}
-                    {% include 'camp_fin/widgets/calendar-form.html' %}
-                {% endwith %}
-                <div class="col-xs-12">
-                    <br/>
-                </div>
-            </div>
-
-            <div class="row">
-                <h4 class="col-xs-12">
-                    <i class="fa fa-fw fa-clock-o"></i>
-                    Employment histories
-                </h4>
-                {% with action='/api/bulk/employments/' icon='fa fa-fw fa-download' title='Employment histories' from_id='from9' to_id='to9' %}
-                    {% include 'camp_fin/widgets/calendar-form.html' %}
-                {% endwith %}
-                <div class="col-xs-12">
-                    <br/>
-                </div>
-            </div>
-            <br/>
         </div>
     </div>
 </div>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,6 @@ python manage.py createcachetable
 python manage.py migrate --noinput
 
 if [ `psql ${DATABASE_URL} -tAX -c "SELECT COUNT(*) FROM camp_fin_candidate"` -eq "0" ]; then
-    python manage.py import_data
     make import/offices import/CON_2023 import/EXP_2023
     python manage.py make_search_index
 fi


### PR DESCRIPTION
## Overview

This PR temporarily removes lobbyist data from the site. It should be reverted when we're able to ingest new lobbyist data in a future phase of work.

## Testing Instructions

* View the deploy preview and confirm the lobbyist data portal is no longer available.
