### PR TITLE
Use the most recent filing, if more than one "final" filing was submitted

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-#        with:
-#          ref: "deploy"
+        with:
+          ref: "deploy"
       - name: Import candidate, PAC, and filing data
         run: |
           touch .env
@@ -29,8 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-#        with:
-#          ref: "deploy"
+        with:
+          ref: "deploy"
       - name: Import data for 2023
         run: |
           touch .env
@@ -47,8 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-#        with:
-#          ref: "deploy"
+        with:
+          ref: "deploy"
       - name: Import data for 2024
         run: |
           touch .env

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: "deploy"
+#        with:
+#          ref: "deploy"
       - name: Import candidate, PAC, and filing data
         run: |
           touch .env
@@ -29,8 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: "deploy"
+#        with:
+#          ref: "deploy"
       - name: Import data for 2023
         run: |
           touch .env
@@ -47,8 +47,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: "deploy"
+#        with:
+#          ref: "deploy"
       - name: Import data for 2024
         run: |
           touch .env

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -259,7 +259,15 @@ class Command(BaseCommand):
         except models.Filing.DoesNotExist:
             raise ValueError
         except models.Filing.MultipleObjectsExist:
-            msg = f"{filings.count()} filings found for PAC {pac} from record {record}: {filings}"
+            filing_meta = filings.values(
+                "campaign__committee__name",
+                "entity",
+                "filing_period__description",
+                "filed_date",
+                "filing_period__initial_date",
+                "filing_period__end_date",
+            )
+            msg = f"{filings.count()} filings found for PAC {pac} from record {record}: {filing_meta}"
             self.stderr.write(msg)
             raise ValueError(msg)
 

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -259,6 +259,7 @@ class Command(BaseCommand):
         except models.Filing.DoesNotExist:
             raise ValueError
         except models.Filing.MultipleObjectsReturned:
+            filing = filings.order_by("filed_date").last()
             filing_meta = filings.values(
                 "campaign__committee__name",
                 "entity",
@@ -267,9 +268,8 @@ class Command(BaseCommand):
                 "filing_period__initial_date",
                 "filing_period__end_date",
             )
-            msg = f"{filings.count()} filings found for PAC {pac} from record {record}: {filing_meta}"
+            msg = f"{filings.count()} filings found for PAC {pac} from record {record}:\n{filing_meta}\n\nUsing most recent filing matching query..."
             self.stderr.write(msg)
-            raise ValueError(msg)
 
         return filing
 

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -258,7 +258,7 @@ class Command(BaseCommand):
             filing = filings.get()
         except models.Filing.DoesNotExist:
             raise ValueError
-        except models.Filing.MultipleObjectsExist:
+        except models.Filing.MultipleObjectsReturned:
             filing_meta = filings.values(
                 "campaign__committee__name",
                 "entity",


### PR DESCRIPTION
## Overview

Sometimes filings are marked as final, even though another copy was submitted later. For example: 

- Submitted 6/7: https://login.cfis.sos.state.nm.us//ReportsOutput//103/d92b2c52-dfaf-415b-8c64-058d848df9c2.pdf
- Submitted 6/28: https://login.cfis.sos.state.nm.us//ReportsOutput//103/684f4f2c-5cff-4f1f-b25f-6be2bd6c0277.pdf

We could [continue to try to keep track of these instances](https://github.com/datamade/openness-project-nmid/blob/e003c062cde60fd28399af5163423ac8feee993a/camp_fin/management/commands/import_filing.py#L37), but that requires manual intervention in a loooong feedback loop. Instead, where there is more than one filing for a particular period, use the most recently filed one.

I added a log message to indicate when this is happening, as well.

### Notes

My manually triggered workflows are running significantly slower than the repo triggered ones, including the failed run that happened overnight (2 it/s vs. > 40 it/s), despite minimal code changes. Want to let this run via the usual ETL and see what happens.

## Testing Instructions

Manually triggered a workflow. [It ran until it timed out.](https://github.com/datamade/openness-project-nmid/actions/runs/9963209082)