### PR TITLE
Import transactions by quarter, in chunks of a few hundred

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "deploy"
+          ref: "hcg/batch-it-up"
       - name: Import transaction data
         run: |
           touch .env

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -23,15 +23,20 @@ jobs:
             -e DATABASE_URL=${{ secrets.DATABASE_URL }} \
             app make import/candidates import/pacs import/candidate_filings import/pac_filings
 
-  import_2023:
+  import_transactions:
     runs-on: ubuntu-latest
     needs: import_filings
+    strategy:
+      matrix:
+        transaction_type: [CON, EXP]
+        year: [2023, 2024]
+        quarter: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v3
         with:
           ref: "deploy"
-      - name: Import data for 2023
+      - name: Import transaction data
         run: |
           touch .env
           docker compose -f docker-compose.etl.yml run --rm \
@@ -39,22 +44,4 @@ jobs:
             -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             -e DATABASE_URL=${{ secrets.DATABASE_URL }} \
-            app make import/CON_2023 import/EXP_2023
-
-  import_2024:
-    runs-on: ubuntu-latest
-    needs: import_filings
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: "deploy"
-      - name: Import data for 2024
-        run: |
-          touch .env
-          docker compose -f docker-compose.etl.yml run --rm \
-            -e AWS_STORAGE_BUCKET_NAME=${{ secrets.AWS_STORAGE_BUCKET_NAME }} \
-            -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-            -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
-            -e DATABASE_URL=${{ secrets.DATABASE_URL }} \
-            app make import/CON_2024 import/EXP_2024
+            app make import/${{ matrix.transaction_type }}_${{ matrix.quarter }}_${{ matrix.year }}

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ quarterly: import/candidates import/pacs import/candidate_filings import/pac_fil
 nightly: import/candidates import/pacs import/candidate_filings import/pac_filings import/CON_2023 import/EXP_2023 import/CON_2024 import/EXP_2024
 	python manage.py make_search_index
 
-import/% : _data/sorted/%.csv
+.SECONDEXPANSION:
+import/% : _data/sorted/$$(word 1, $$(subst _, , $$*))_$$(word 3, $$(subst _, , $$*)).csv
 	python manage.py import_transactions --transaction-type $(word 1, $(subst _, , $*)) \
-		--year $(word 2, $(subst _, , $*)) \
+		--months $(word 2, $(subst _, , $*)) \
+		--year $(word 3, $(subst _, , $*)) \
 		--file $<
 
 import/pac_filings : _data/raw/pac_committee_filings.csv
@@ -29,7 +31,6 @@ _data/raw/%_committees.csv :
 
 _data/raw/%_committee_filings.csv :
 	wget --no-check-certificate --no-use-server-timestamps -O $@ "https://openness-project-nmid.s3.amazonaws.com/$*_committee_filings.csv"
-
 
 _data/sorted/%.csv : _data/raw/%.csv
 	xsv fixlengths $< | xsv sort -s OrgID,"Report Name","Start of Period","End of Period" > $@

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -498,9 +498,7 @@ class Command(BaseCommand):
         for filing in tqdm(models.Filing.objects.filter(
             final=True,
             filing_period__initial_date__month__gte=start,
-            filing_period__initial_date__month__lte=end,
-            filing_period__initial_date__year__lte=year,
-            filing_period__end_date__year__gte=year,
+            filing_period__initial_date__month__lte=end
         ).iterator()):
             contributions = filing.contributions().aggregate(total=Sum("amount"))
             expenditures = filing.expenditures().aggregate(total=Sum("amount"))

--- a/camp_fin/tests/docker-compose.yml
+++ b/camp_fin/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   app:
     # Don't restart the service when the command exits

--- a/docker-compose.etl.yml
+++ b/docker-compose.etl.yml
@@ -1,9 +1,7 @@
-version: '2.4'
-
 services:
   app:
     image: nmid
-    build: .    
+    build: .
     container_name: nmid-etl
     environment:
       DJANGO_SECRET_KEY: "etl secret key"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: '2.4'
-
 services:
   app:
     image: nmid
-    build: .    
+    build: .
     container_name: nmid
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Overview

The transaction import makes something like 10 database calls per iteration. That can really slow us down when our database connection and/or cloud compute environment isn't zippy (#210). 

This PR reduces the number of iterations from n to roughly n/4 by slicing the import by quarter and reduces the number of database calls (made from transaction saves, other queries are unaffected) from n to n/500 by batching transaction saves in chunks of 500. Both of these options are configurable, but are given reasonable defaults.

It further reduces run time by importing only one transaction type per job, rather than both contributions and expenditures. Jobs are now created per a matrix strategy, so that all transaction imports run concurrently.

Connects #210.

### Notes

I initially did a month filter, but filing periods tend to correspond to quarters, so some months have no filings. I thought it better to do quarters for jobs of roughly equal size, but with no waste jobs (i.e., jobs that don't import anything).

The quarter and year parameters are a little confusing.

When filing period spans years, its transactions can occur across two data files. The year is the vintage of the data file, not the transaction date or filing period, and is used to remove only transactions from a given filing in the given year (i.e., ones that should be reimported in a given run).

The quarter is used to filter filings to only those with a filing period beginning in the given quarter *of any year*. In this way, it accounts for filings spanning years. For example, consider a filing period starting in December 2023 and ending in February 2024. Transactions would be split across the 2023 and 2024 files. To get them all, you would run the Q4 import for both 2023 and 2024.

## Testing Instructions

* Succeeding run, here: https://github.com/datamade/openness-project-nmid/actions/runs/10949625887
