### PR TITLE
_save_batch() should not be a generator

### DIFF
--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "deploy"
+          ref: "hcg/delete-fix-2"
       - name: Import transaction data
         run: |
           touch .env

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -156,7 +156,6 @@ class Command(BaseCommand):
                     try:
                         filing = self._get_filing(record)
                     except ValueError:
-                        self.stderr.write(f"Could not get filing from record: {record}")
                         break
 
                     # The contributions files are organized by the year


### PR DESCRIPTION
## Overview

### Change ref in workflow back to deploy before merging and deploying.

I introduced a bug by making `_save_batch()` a generator. Generators are great in that they are lazy, but that's only great if you actually iterate them. 🫠 There's no reason for the save method to be a generator, so I made it a regular function instead. I also turned up the logging so we have a better idea of the record churn for future debugging endeavors.

Addresses Marjorie's email.

## Testing Instructions

Running on: https://github.com/datamade/openness-project-nmid/actions/runs/11108320332
