### PR TITLE
Convert available funds / contributions/expenditures from area to step charts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,21 +25,6 @@ repos:
         files: .*/templates/.*\.html$
         args: [--tabwidth=2] # tabs should be 2 spaces in Django templates
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
-    hooks:
-      - id: prettier
-        files: \.(js|ts|jsx|tsx|css|less|json|markdown|md|yaml|yml)$
-
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: "1f7d592"
-    hooks:
-      - id: eslint
-        additional_dependencies:
-          - eslint@8.19.0
-          - eslint-plugin-react@7.30.1
-          - eslint-config-prettier@8.5.0
-
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/camp_fin/management/commands/aggregate_data.py
+++ b/camp_fin/management/commands/aggregate_data.py
@@ -38,6 +38,31 @@ class Command(BaseCommand):
                     )
                 )
 
+            continuous_interval_query = """
+                CREATE MATERIALIZED VIEW {transaction_type}_by_{interval} AS (
+                    WITH {interval}_summaries AS (
+                        {summary_query}
+                    )
+                    SELECT
+                        continuous_interval.entity_id,
+                        continuous_interval.{interval},
+                        COALESCE({interval}_summaries.amount, 0) AS amount
+                    FROM (
+                        SELECT DISTINCT
+                            entity_id,
+                            generate_series(
+                                MIN({interval}) OVER (PARTITION BY entity_id),
+                                MAX({interval}) OVER (PARTITION BY entity_id),
+                                '1 {interval}'
+                            ) AS {interval}
+                        FROM {interval}_summaries
+                    ) continuous_interval
+                    LEFT JOIN {interval}_summaries
+                    USING (entity_id, {interval})
+                    ORDER BY entity_id, {interval}
+                )
+            """
+
             try:
                 self.executeTransaction(
                     """
@@ -47,17 +72,16 @@ class Command(BaseCommand):
                     )
                 )
             except ProgrammingError:
-                view = """
-                    CREATE MATERIALIZED VIEW contributions_by_{0} AS (
-                      SELECT
+                summary_query = """
+                    SELECT
                         SUM(amount) AS amount,
                         entity_id,
-                        {0}
-                      FROM (
+                        {interval}
+                    FROM (
                         SELECT
                           SUM(t.amount) AS amount,
                           f.entity_id,
-                          MAX(date_trunc('{0}', t.received_date)) AS {0}
+                          MAX(date_trunc('{interval}', t.received_date)) AS {interval}
                         FROM camp_fin_transaction AS t
                         JOIN camp_fin_transactiontype AS tt
                           ON t.transaction_type_id = tt.id
@@ -68,21 +92,26 @@ class Command(BaseCommand):
                             'Monetary Contribution',
                             'Anonymous Contribution'
                           )
-                        GROUP BY f.entity_id, date_trunc('{0}', t.received_date)
+                        GROUP BY f.entity_id, date_trunc('{interval}', t.received_date)
                         UNION
                         SELECT
                           SUM(l.amount) AS amount,
                           f.entity_id,
-                          MAX(date_trunc('{0}', l.received_date)) AS {0}
+                          MAX(date_trunc('{interval}', l.received_date)) AS {interval}
                         FROM camp_fin_loan AS l
                         JOIN camp_fin_filing AS f
                           ON l.filing_id = f.id
-                        GROUP BY f.entity_id, date_trunc('{0}', l.received_date)
-                      ) AS s
-                      GROUP BY entity_id, {0}
-                    )
+                        GROUP BY f.entity_id, date_trunc('{interval}', l.received_date)
+                    ) contributions_and_loans
+                        GROUP BY entity_id, {interval}
                 """.format(
-                    interval
+                    interval=interval
+                )
+
+                view = continuous_interval_query.format(
+                    transaction_type="contributions",
+                    summary_query=summary_query,
+                    interval=interval,
                 )
 
                 self.executeTransaction(view)
@@ -96,17 +125,16 @@ class Command(BaseCommand):
                     )
                 )
             except ProgrammingError:
-                view = """
-                    CREATE MATERIALIZED VIEW expenditures_by_{0} AS (
+                summary_query = """
                       SELECT
                         entity_id,
                         SUM(amount) AS amount,
-                        {0}
+                        {interval}
                       FROM (
                         SELECT
                           filing.entity_id,
                           SUM(e.amount) AS amount,
-                          date_trunc('{0}', e.received_date) AS {0}
+                          date_trunc('{interval}', e.received_date) AS {interval}
                         FROM camp_fin_transaction AS e
                         JOIN camp_fin_transactiontype AS tt
                           ON e.transaction_type_id = tt.id
@@ -116,14 +144,14 @@ class Command(BaseCommand):
                           ON filing.filing_period_id = fp.id
                         WHERE tt.contribution = FALSE
                           AND filing.filed_date >= '2010-01-01'
-                        GROUP BY filing.entity_id, date_trunc('{0}', e.received_date)
+                        GROUP BY filing.entity_id, date_trunc('{interval}', e.received_date)
 
                         UNION
 
                         SELECT
                           filing.entity_id,
                           SUM(lt.amount) AS amount,
-                          date_trunc('{0}', lt.transaction_date) AS {0}
+                          date_trunc('{interval}', lt.transaction_date) AS {interval}
                         FROM camp_fin_loantransaction AS lt
                         JOIN camp_fin_loantransactiontype AS ltt
                           ON lt.transaction_type_id = ltt.id
@@ -133,12 +161,17 @@ class Command(BaseCommand):
                           ON filing.filing_period_id = fp.id
                         WHERE ltt.description = 'Payment'
                           AND filing.filed_date >= '2010-01-01'
-                        GROUP BY filing.entity_id, date_trunc('{0}', lt.transaction_date)
+                        GROUP BY filing.entity_id, date_trunc('{interval}', lt.transaction_date)
                       ) AS s
-                      GROUP BY entity_id, {0}
-                    )
+                      GROUP BY entity_id, {interval}
                 """.format(
-                    interval
+                    interval=interval
+                )
+
+                view = continuous_interval_query.format(
+                    transaction_type="expenditures",
+                    summary_query=summary_query,
+                    interval=interval,
                 )
 
                 self.executeTransaction(view)

--- a/camp_fin/models.py
+++ b/camp_fin/models.py
@@ -945,10 +945,10 @@ class Entity(models.Model):
         # Balances and debts
         summed_filings = """
             SELECT
-              COALESCE(f.total_unpaid_debts, 0) AS total_unpaid_debts,
-              f.closing_balance AS closing_balance,
+              SUM(COALESCE(f.total_unpaid_debts, 0)) AS total_unpaid_debts,
+              SUM(f.closing_balance) AS closing_balance,
               fp.end_date,
-              fp.description
+              ARRAY_AGG(fp.description) AS description
             FROM camp_fin_filing AS f
             JOIN camp_fin_filingperiod AS fp
               ON f.filing_period_id = fp.id
@@ -956,6 +956,7 @@ class Entity(models.Model):
               AND fp.exclude_from_cascading = FALSE
               AND fp.regular_filing_period_id IS NULL
               AND f.filed_date >= '{year}-01-01'
+            GROUP BY fp.end_date
             ORDER BY fp.end_date
         """.format(
             year=since

--- a/camp_fin/static/css/custom.css
+++ b/camp_fin/static/css/custom.css
@@ -210,8 +210,6 @@ a.collapsed .show-less {
   background-color: #5b0007;
 }
 
-/*#net-funds-chart { height: 200px; }*/
-
 #date-search .form-control { width: 48%; }
 
 #date-search { margin-top: 21px; }

--- a/camp_fin/static/css/custom.css
+++ b/camp_fin/static/css/custom.css
@@ -210,7 +210,7 @@ a.collapsed .show-less {
   background-color: #5b0007;
 }
 
-#net-funds-chart { height: 200px; }
+/*#net-funds-chart { height: 200px; }*/
 
 #date-search .form-control { width: 48%; }
 

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -96,7 +96,7 @@ ChartHelper.donations = function(el, title, sourceTxt, yaxisLabel, data, pointIn
     });
   }
 
-ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
+ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYear, endYear) {
   var color = '#007E85';
 
   var seriesData = [{
@@ -114,9 +114,7 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "area",
-          marginRight: 10,
-          marginBottom: 25
+          type: "line",
       },
       legend: {
         backgroundColor: "#ffffff",
@@ -130,18 +128,28 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
       title: null,
       xAxis: {
           dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
+          type: "datetime",
+          title: {
+            enabled: true,
+            text: "Filing date"
+          },
+          tickPixelInterval: 50,
+          min: Date.UTC(startYear, 1, 1),
+          max: Date.UTC(endYear+1, 1, 1),
+          startOnTick: true,
       },
       yAxis: {
-          title: null
+          title: {
+            text: yaxisLabel
+          }
       },
       plotOptions: {
         line: {
           animation: false
         },
         series: {
+          step: true,
           marker: {
-            fillColor: color,
             radius: 0,
             states: {
               hover: {
@@ -150,7 +158,12 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
               }
             }
           },
-          shadow: false
+          shadow: false,
+          states: {
+            hover: {
+              lineWidthPlus: 0
+            }
+          }
         }
       },
       tooltip: {
@@ -168,7 +181,7 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
     });
   }
 
-ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, data) {
+ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, data, startYear, endYear) {
   var color = '#007E85';
 
   var seriesData = [{
@@ -187,8 +200,6 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
       chart: {
           renderTo: el,
           type: "line",
-          marginRight: 10,
-          marginBottom: 25
       },
       legend: {
         backgroundColor: "#ffffff",
@@ -201,17 +212,26 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
       },
       title: null,
       xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
+          dateTimeLabelFormats: { year: "%b '%y" },
+          type: "datetime",
+          title: {
+            enabled: true,
+            text: "Month",
+          },
+          tickPixelInterval: 50,
+          min: Date.UTC(startYear, 1, 1),
+          max: Date.UTC(endYear+1, 1, 1),
+          startOnTick: true,
       },
       yAxis: {
-          title: null
+          title: {
+            text: yaxisLabel
+          }
       },
       plotOptions: {
         series: {
           step: true,
           marker: {
-            fillColor: color,
             radius: 0,
             states: {
               hover: {
@@ -220,7 +240,12 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
               }
             }
           },
-          shadow: false
+          shadow: false,
+          states: {
+            hover: {
+              lineWidthPlus: 0
+            }
+          }
         }
       },
       tooltip: {

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -210,7 +210,6 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
       plotOptions: {
         series: {
           step: true,
-          shade: true,
           marker: {
             fillColor: color,
             radius: 0,

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -114,7 +114,7 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYea
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "area",
+          type: "line",
       },
       legend: {
         backgroundColor: "#ffffff",
@@ -206,7 +206,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "area",
+          type: "line",
       },
       legend: {
         backgroundColor: "#ffffff",

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -114,7 +114,7 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYea
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "line",
+          type: "area",
       },
       legend: {
         backgroundColor: "#ffffff",
@@ -127,13 +127,13 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYea
       },
       title: null,
       xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
+          dateTimeLabelFormats: { year: "%b '%y" },
           type: "datetime",
           title: {
             enabled: true,
-            text: "Filing date"
+            text: "Filing period end date"
           },
-          tickPixelInterval: 50,
+          tickPixelInterval: 75,
           min: Date.UTC(startYear, 1, 1),
           max: Date.UTC(endYear+1, 1, 1),
           startOnTick: true,
@@ -168,9 +168,16 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYea
       },
       tooltip: {
           crosshairs: true,
+          useHTML: true,
           formatter: function() {
-            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
+            let s = ""
             $.each(this.points, function(i, point) {
+              if (i === 0) {
+                s += `
+                  <strong>${point.point.description}</strong><br />
+                  <strong>Period ending ${ChartHelper.toolTipDateFormat("day", this.x)}</strong>
+                `
+              }
               s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
             });
             return s;
@@ -199,7 +206,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "line",
+          type: "area",
       },
       legend: {
         backgroundColor: "#ffffff",
@@ -218,7 +225,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
             enabled: true,
             text: "Month",
           },
-          tickPixelInterval: 50,
+          tickPixelInterval: 75,
           min: Date.UTC(startYear, 1, 1),
           max: Date.UTC(endYear+1, 1, 1),
           startOnTick: true,
@@ -250,6 +257,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
       },
       tooltip: {
           crosshairs: true,
+          useHTML: true,
           formatter: function() {
             var s = "<strong>" + ChartHelper.toolTipDateFormat("month", this.x) + "</strong>";
             $.each(this.points, function(i, point) {

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -186,7 +186,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
   return new Highcharts.Chart({
       chart: {
           renderTo: el,
-          type: "area",
+          type: "line",
           marginRight: 10,
           marginBottom: 25
       },
@@ -208,10 +208,9 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
           title: null
       },
       plotOptions: {
-        line: {
-          animation: false
-        },
         series: {
+          step: true,
+          shade: true,
           marker: {
             fillColor: color,
             radius: 0,
@@ -234,7 +233,7 @@ ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, da
             });
             return s;
           },
-          shared: true
+          shared: true,
       },
       series: seriesData
     });

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -174,7 +174,7 @@ ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data, startYea
             $.each(this.points, function(i, point) {
               if (i === 0) {
                 s += `
-                  <strong>${point.point.description}</strong><br />
+                  <strong>${point.point.description.join(", ")}</strong><br />
                   <strong>Period ending ${ChartHelper.toolTipDateFormat("day", this.x)}</strong>
                 `
               }

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -1,5 +1,12 @@
 var ChartHelper = {};
-ChartHelper.donations = function(el, title, sourceTxt, yaxisLabel, data, pointInterval) {
+ChartHelper.donations = function (
+  el,
+  title,
+  sourceTxt,
+  yaxisLabel,
+  data,
+  pointInterval
+) {
   // console.log("rendering to: #chart_" + iteration);
   // console.log("title: " + title);
   // console.log("sourceTxt: " + sourceTxt);
@@ -14,434 +21,476 @@ ChartHelper.donations = function(el, title, sourceTxt, yaxisLabel, data, pointIn
   // var selected = data.indexOf(Date.parse(start_date));
   // console.log(selected);
 
-  var color = '#007F00';
+  var color = "#007F00";
 
-  var seriesData = [{
+  var seriesData = [
+    {
       color: color,
       data: data,
       name: title,
       showInLegend: false,
-      lineWidth: 2
-  }];
+      lineWidth: 2,
+    },
+  ];
 
   //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
   return new Highcharts.Chart({
-      chart: {
-          renderTo: el,
-          type: "column",
-          marginRight: 10,
-          marginBottom: 25
+    chart: {
+      renderTo: el,
+      type: "column",
+      marginRight: 10,
+      marginBottom: 25,
+    },
+    legend: {
+      backgroundColor: "#ffffff",
+      borderColor: "#cccccc",
+      floating: true,
+      verticalAlign: "top",
+    },
+    credits: {
+      enabled: false,
+    },
+    title: null,
+    xAxis: {
+      dateTimeLabelFormats: { year: "%Y" },
+      type: "datetime",
+    },
+    yAxis: {
+      title: yaxisLabel,
+      min: 0,
+    },
+    plotOptions: {
+      line: {
+        animation: false,
       },
-      legend: {
-        backgroundColor: "#ffffff",
-        borderColor: "#cccccc",
-        floating: true,
-        verticalAlign: "top"
-      },
-      credits: {
-        enabled: false
-      },
-      title: null,
-      xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
-      },
-      yAxis: {
-          title: yaxisLabel,
-          min: 0
-      },
-      plotOptions: {
-        line: {
-          animation: false
+      series: {
+        point: {
+          events: {
+            click: function () {
+              var date = moment.utc(new Date(this.x)).format("YYYY-MM-DD");
+              window.location.href = "/donations?date=" + date;
+            },
+          },
         },
-        series: {
-          point: {
-            events: {
-              click: function() {
-                var date = moment.utc(new Date(this.x)).format('YYYY-MM-DD');
-                window.location.href = '/donations?date=' + date;
-              }
-            }
-          },
-          marker: {
-            fillColor: color,
-            radius: 0,
-            states: {
-              hover: {
-                enabled: true,
-                radius: 5
-              }
-            }
-          },
-          shadow: false,
+        marker: {
+          fillColor: color,
+          radius: 0,
           states: {
-             hover: {
-                lineWidth: 2
-             }
-          }
-        }
-      },
-      tooltip: {
-          crosshairs: true,
-          formatter: function() {
-            var s = "<strong>" + ChartHelper.toolTipDateFormat(pointInterval, this.x) + "</strong>";
-            $.each(this.points, function(i, point) {
-              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
-            });
-            return s;
+            hover: {
+              enabled: true,
+              radius: 5,
+            },
           },
-          shared: true
+        },
+        shadow: false,
+        states: {
+          hover: {
+            lineWidth: 2,
+          },
+        },
       },
-      series: seriesData
-    });
-  }
+    },
+    tooltip: {
+      crosshairs: true,
+      formatter: function () {
+        var s =
+          "<strong>" +
+          ChartHelper.toolTipDateFormat(pointInterval, this.x) +
+          "</strong>";
+        $.each(this.points, function (i, point) {
+          s +=
+            "<br /><span style='color: " +
+            point.series.color +
+            "'>" +
+            point.series.name +
+            ":</span> $" +
+            Highcharts.numberFormat(point.y, 0, ".", ",");
+        });
+        return s;
+      },
+      shared: true,
+    },
+    series: seriesData,
+  });
+};
 
-ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
-  var color = '#007E85';
+ChartHelper.netfunds = function (el, title, sourceTxt, yaxisLabel, data) {
+  var color = "#007E85";
 
-  var seriesData = [{
-          color: color,
-          data: data[0],
-          name: "Funds available"
-        },{
-          color: "#DD0000",
-          data: data[1],
-          name: "Debts"
-        }
-      ]
+  var seriesData = [
+    {
+      color: color,
+      data: data[0],
+      name: "Funds available",
+    },
+    {
+      color: "#DD0000",
+      data: data[1],
+      name: "Debts",
+    },
+  ];
 
   //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
   return new Highcharts.Chart({
-      chart: {
-          renderTo: el,
-          type: "area",
-          marginRight: 10,
-          marginBottom: 25
-      },
-      legend: {
-        backgroundColor: "#ffffff",
-        borderColor: "#cccccc",
-        floating: true,
-        verticalAlign: "top"
-      },
-      credits: {
-        enabled: false
-      },
+    chart: {
+      renderTo: el,
+      type: "area",
+      marginRight: 10,
+      marginBottom: 25,
+    },
+    legend: {
+      backgroundColor: "#ffffff",
+      borderColor: "#cccccc",
+      floating: true,
+      verticalAlign: "top",
+    },
+    credits: {
+      enabled: false,
+    },
+    title: null,
+    xAxis: {
+      dateTimeLabelFormats: { year: "%Y" },
+      type: "datetime",
+    },
+    yAxis: {
       title: null,
-      xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
+    },
+    plotOptions: {
+      line: {
+        animation: false,
       },
-      yAxis: {
-          title: null
-      },
-      plotOptions: {
-        line: {
-          animation: false
+      series: {
+        marker: {
+          fillColor: color,
+          radius: 0,
+          states: {
+            hover: {
+              enabled: true,
+              radius: 5,
+            },
+          },
         },
-        series: {
-          marker: {
-            fillColor: color,
-            radius: 0,
-            states: {
-              hover: {
-                enabled: true,
-                radius: 5
-              }
-            }
-          },
-          shadow: false
-        }
+        shadow: false,
       },
-      tooltip: {
-          crosshairs: true,
-          formatter: function() {
-            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
-            $.each(this.points, function(i, point) {
-              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
-            });
-            return s;
-          },
-          shared: true
+    },
+    tooltip: {
+      crosshairs: true,
+      formatter: function () {
+        var s =
+          "<strong>" +
+          ChartHelper.toolTipDateFormat("day", this.x) +
+          "</strong>";
+        $.each(this.points, function (i, point) {
+          s +=
+            "<br /><span style='color: " +
+            point.series.color +
+            "'>" +
+            point.series.name +
+            ":</span> $" +
+            Highcharts.numberFormat(point.y, 0, ".", ",");
+        });
+        return s;
       },
-      series: seriesData
-    });
-  }
+      shared: true,
+    },
+    series: seriesData,
+  });
+};
 
-ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, data) {
-  var color = '#007E85';
+ChartHelper.donation_expenditure = function (
+  el,
+  title,
+  sourceTxt,
+  yaxisLabel,
+  data
+) {
+  var color = "#007E85";
 
-  var seriesData = [{
-          color: color,
-          data: data[0],
-          name: "Donations and loans"
-        },{
-          color: "#DD0000",
-          data: data[1],
-          name: "Expenditures"
-        }
-      ]
+  var seriesData = [
+    {
+      color: color,
+      data: data[0],
+      name: "Donations and loans",
+    },
+    {
+      color: "#DD0000",
+      data: data[1],
+      name: "Expenditures",
+    },
+  ];
 
   //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
   return new Highcharts.Chart({
-      chart: {
-          renderTo: el,
-          type: "area",
-          marginRight: 10,
-          marginBottom: 25
-      },
-      legend: {
-        backgroundColor: "#ffffff",
-        borderColor: "#cccccc",
-        floating: true,
-        verticalAlign: "top"
-      },
-      credits: {
-        enabled: false
-      },
+    chart: {
+      renderTo: el,
+      type: "area",
+      marginRight: 10,
+      marginBottom: 25,
+    },
+    legend: {
+      backgroundColor: "#ffffff",
+      borderColor: "#cccccc",
+      floating: true,
+      verticalAlign: "top",
+    },
+    credits: {
+      enabled: false,
+    },
+    title: null,
+    xAxis: {
+      dateTimeLabelFormats: { year: "%Y" },
+      type: "datetime",
+    },
+    yAxis: {
       title: null,
-      xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
+    },
+    plotOptions: {
+      line: {
+        animation: false,
       },
-      yAxis: {
-          title: null
-      },
-      plotOptions: {
-        line: {
-          animation: false
+      series: {
+        marker: {
+          fillColor: color,
+          radius: 0,
+          states: {
+            hover: {
+              enabled: true,
+              radius: 5,
+            },
+          },
         },
-        series: {
-          marker: {
-            fillColor: color,
-            radius: 0,
-            states: {
-              hover: {
-                enabled: true,
-                radius: 5
-              }
-            }
-          },
-          shadow: false
-        }
+        shadow: false,
       },
-      tooltip: {
-          crosshairs: true,
-          formatter: function() {
-            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
-            $.each(this.points, function(i, point) {
-              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
-            });
-            return s;
-          },
-          shared: true
+    },
+    tooltip: {
+      crosshairs: true,
+      formatter: function () {
+        var s =
+          "<strong>" +
+          ChartHelper.toolTipDateFormat("month", this.x) +
+          "</strong>";
+        $.each(this.points, function (i, point) {
+          s +=
+            "<br /><span style='color: " +
+            point.series.color +
+            "'>" +
+            point.series.name +
+            ":</span> $" +
+            Highcharts.numberFormat(point.y, 0, ".", ",");
+        });
+        return s;
       },
-      series: seriesData
-    });
-  }
+      shared: true,
+    },
+    series: seriesData,
+  });
+};
 
-ChartHelper.smallDonationExpend = function(el, min_max, data) {
+ChartHelper.smallDonationExpend = function (el, min_max, data) {
   var min = min_max[0];
   var max = min_max[1];
-  var color = '#007E85';
+  var color = "#007E85";
 
-  var seriesData = [{
-          color: color,
-          data: data[0],
-          name: "Donations"
-        },{
-          color: "#DD0000",
-          data: data[1],
-          name: "Expenditures"
-        }
-      ]
+  var seriesData = [
+    {
+      color: color,
+      data: data[0],
+      name: "Donations",
+    },
+    {
+      color: "#DD0000",
+      data: data[1],
+      name: "Expenditures",
+    },
+  ];
 
   return new Highcharts.Chart({
-      chart: {
-          renderTo: el,
-          type: "area",
-          marginRight: 10,
-          marginBottom: 25,
-          backgroundColor: null,
-          height: 100,
-      },
-      legend: {
-        enabled: false
-      },
-      credits: {
-        enabled: false
-      },
+    chart: {
+      renderTo: el,
+      type: "area",
+      marginRight: 10,
+      marginBottom: 25,
+      backgroundColor: null,
+      height: 100,
+    },
+    legend: {
+      enabled: false,
+    },
+    credits: {
+      enabled: false,
+    },
+    title: null,
+    xAxis: {
+      dateTimeLabelFormats: { year: "%Y" },
+      type: "datetime",
+    },
+    yAxis: {
       title: null,
-      xAxis: {
-          dateTimeLabelFormats: { year: "%Y" },
-          type: "datetime"
+      max: max,
+      min: min,
+    },
+    plotOptions: {
+      line: {
+        animation: false,
       },
-      yAxis: {
-          title: null,
-          max: max,
-          min: min
-      },
-      plotOptions: {
-        line: {
-          animation: false
-        },
-        series: {
-          marker: {
-            fillColor: color,
-            radius: 0,
-            states: {
-              hover: {
-                enabled: true,
-                radius: 5
-              }
-            }
+      series: {
+        marker: {
+          fillColor: color,
+          radius: 0,
+          states: {
+            hover: {
+              enabled: true,
+              radius: 5,
+            },
           },
-          shadow: false
-        }
+        },
+        shadow: false,
       },
-      tooltip: {
-          crosshairs: true,
-          formatter: function() {
-            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
-            $.each(this.points, function(i, point) {
-              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
-            });
-            return s;
+    },
+    tooltip: {
+      crosshairs: true,
+      formatter: function () {
+        var s =
+          "<strong>" +
+          ChartHelper.toolTipDateFormat("day", this.x) +
+          "</strong>";
+        $.each(this.points, function (i, point) {
+          s +=
+            "<br /><span style='color: " +
+            point.series.color +
+            "'>" +
+            point.series.name +
+            ":</span> $" +
+            Highcharts.numberFormat(point.y, 0, ".", ",");
+        });
+        return s;
+      },
+      shared: true,
+    },
+    series: seriesData,
+  });
+};
+
+ChartHelper.initQualityChart = function (el) {
+  $("#" + el).highcharts({
+    chart: {
+      type: "bar",
+    },
+    credits: {
+      enabled: false,
+    },
+    title: {
+      text: null,
+    },
+    xAxis: {
+      title: null,
+      labels: {
+        enabled: false,
+      },
+    },
+    yAxis: {
+      title: null,
+      min: 1989,
+      max: 2015,
+      labels: {
+        formatter: function () {
+          return parseInt(this.value);
+        },
+      },
+    },
+    plotOptions: {
+      series: {
+        stacking: "true",
+        events: {
+          legendItemClick: function () {
+            return false;
           },
-          shared: true
+        },
       },
-      series: seriesData
+    },
+    tooltip: {
+      borderColor: "#ccc",
+      formatter: function () {
+        return this.series.name;
+      },
+    },
+    legend: { reversed: true },
+    series: [
+      {
+        name: "2000 on: Electronic filings",
+        data: [15],
+        color: "#43ac6a",
+      },
+      {
+        name: "1999: Incomplete",
+        data: [1],
+        color: "#d9edf7",
+      },
+      {
+        name: "1994 - 1999: Manually entered",
+        data: [5],
+        color: "#43ac6a",
+      },
+      {
+        name: "1989 - 1994: Bad entries",
+        data: [1994],
+        color: "#d9edf7",
+      },
+    ],
   });
-}
+};
 
-ChartHelper.initQualityChart = function(el) {
-  $('#' + el).highcharts({
-      chart: {
-          type: 'bar'
-      },
-      credits: {
-        enabled: false
-      },
-      title: {
-          text: null
-      },
-      xAxis: {
-        title: null,
-          labels: {
-            enabled: false
-          }
-      },
-      yAxis:{
-          title: null,
-          min: 1989,
-          max: 2015,
-          labels: {
-            formatter: function() { return parseInt(this.value); }
-          }
-      },
-      plotOptions: {
-          series: {
-              stacking: 'true',
-              events: {
-                legendItemClick: function () {
-                  return false;
-              }
-            }
-          }
-      },
-      tooltip: {
-        borderColor: "#ccc",
-        formatter: function() {
-          return this.series.name;
-        }
-      },
-      legend: { reversed: true },
-      series: [
-        {
-          name: '2000 on: Electronic filings',
-          data: [ 15 ],
-          color: "#43ac6a",
-        },
-        {
-          name: '1999: Incomplete',
-          data: [ 1 ],
-          color: "#d9edf7"
-        },
-        {
-          name: '1994 - 1999: Manually entered',
-          data: [ 5 ],
-          color: "#43ac6a"
-        },
-        {
-          name: '1989 - 1994: Bad entries',
-          data: [ 1994 ],
-          color: "#d9edf7"
-        }
-      ]
-  });
-}
-
-ChartHelper.pointInterval = function(interval) {
-  if (interval == "year")
-    return 365 * 24 * 3600 * 1000;
-  if (interval == "quarter")
-    return 3 * 30.4 * 24 * 3600 * 1000;
-  if (interval == "month") //this is very hacky. months have different day counts, so our point interval is the average - 30.4
-    return 30.4 * 24 * 3600 * 1000;
-  if (interval == "week")
-    return 7 * 24 * 3600 * 1000;
-  if (interval == "day")
-    return 24 * 3600 * 1000;
-  if (interval == "hour")
-    return 3600 * 1000;
-  else
-    return 1;
-}
-
-ChartHelper.toolTipDateFormat = function(interval, x) {
-  if (interval == "year")
-    return Highcharts.dateFormat("%Y", x);
-  if (interval == "quarter")
-    return Highcharts.dateFormat("%B %Y", x);
+ChartHelper.pointInterval = function (interval) {
+  if (interval == "year") return 365 * 24 * 3600 * 1000;
+  if (interval == "quarter") return 3 * 30.4 * 24 * 3600 * 1000;
   if (interval == "month")
-    return Highcharts.dateFormat("%B %Y", x);
-  if (interval == "week")
-    return Highcharts.dateFormat("%e %b %Y", x);
-  if (interval == "day")
-    return Highcharts.dateFormat("%e %b %Y", x);
-  if (interval == "hour")
-    return Highcharts.dateFormat("%H:00", x);
-  else
-    return 1;
-}
+    //this is very hacky. months have different day counts, so our point interval is the average - 30.4
+    return 30.4 * 24 * 3600 * 1000;
+  if (interval == "week") return 7 * 24 * 3600 * 1000;
+  if (interval == "day") return 24 * 3600 * 1000;
+  if (interval == "hour") return 3600 * 1000;
+  else return 1;
+};
+
+ChartHelper.toolTipDateFormat = function (interval, x) {
+  if (interval == "year") return Highcharts.dateFormat("%Y", x);
+  if (interval == "quarter") return Highcharts.dateFormat("%B %Y", x);
+  if (interval == "month") return Highcharts.dateFormat("%B %Y", x);
+  if (interval == "week") return Highcharts.dateFormat("%e %b %Y", x);
+  if (interval == "day") return Highcharts.dateFormat("%e %b %Y", x);
+  if (interval == "hour") return Highcharts.dateFormat("%H:00", x);
+  else return 1;
+};
 
 // x is difference between beginning and end of reporting period in weeks (can be a float)
 // y amount contributed within period / x
-ChartHelper.generateSeriesData = function(listOfData) {
-    var sumX = 0.0;
-    for (var i = 0; i < listOfData.length; i++) {
-        sumX += listOfData[i].x;
-    }
-    var gap = sumX / listOfData.length * 0.2;
-    var allSeries = []
-    var x = 0.0;
-    for (var i = 0; i < listOfData.length; i++) {
-        var data = listOfData[i];
-        allSeries[i] = {
-            name: data.name,
-            data: [
-                [x, 0], [x, data.y],
-                {
-                    x: x + data.x / 2.0,
-                    y: data.y
-                    // dataLabels: { enabled: true, format: data.x + ' x {y}' }
-                },
-                [x + data.x, data.y], [x + data.x, 0]
-            ],
-            w: data.x,
-            h: data.y
-        };
-        x += data.x + gap;
-    }
-    return allSeries;
-}
+ChartHelper.generateSeriesData = function (listOfData) {
+  var sumX = 0.0;
+  for (var i = 0; i < listOfData.length; i++) {
+    sumX += listOfData[i].x;
+  }
+  var gap = (sumX / listOfData.length) * 0.2;
+  var allSeries = [];
+  var x = 0.0;
+  for (var i = 0; i < listOfData.length; i++) {
+    var data = listOfData[i];
+    allSeries[i] = {
+      name: data.name,
+      data: [
+        [x, 0],
+        [x, data.y],
+        {
+          x: x + data.x / 2.0,
+          y: data.y,
+          // dataLabels: { enabled: true, format: data.x + ' x {y}' }
+        },
+        [x + data.x, data.y],
+        [x + data.x, 0],
+      ],
+      w: data.x,
+      h: data.y,
+    };
+    x += data.x + gap;
+  }
+  return allSeries;
+};

--- a/camp_fin/static/js/chart_helper.js
+++ b/camp_fin/static/js/chart_helper.js
@@ -1,12 +1,5 @@
 var ChartHelper = {};
-ChartHelper.donations = function (
-  el,
-  title,
-  sourceTxt,
-  yaxisLabel,
-  data,
-  pointInterval
-) {
+ChartHelper.donations = function(el, title, sourceTxt, yaxisLabel, data, pointInterval) {
   // console.log("rendering to: #chart_" + iteration);
   // console.log("title: " + title);
   // console.log("sourceTxt: " + sourceTxt);
@@ -21,476 +14,434 @@ ChartHelper.donations = function (
   // var selected = data.indexOf(Date.parse(start_date));
   // console.log(selected);
 
-  var color = "#007F00";
+  var color = '#007F00';
 
-  var seriesData = [
-    {
+  var seriesData = [{
       color: color,
       data: data,
       name: title,
       showInLegend: false,
-      lineWidth: 2,
-    },
-  ];
+      lineWidth: 2
+  }];
 
   //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
   return new Highcharts.Chart({
-    chart: {
-      renderTo: el,
-      type: "column",
-      marginRight: 10,
-      marginBottom: 25,
-    },
-    legend: {
-      backgroundColor: "#ffffff",
-      borderColor: "#cccccc",
-      floating: true,
-      verticalAlign: "top",
-    },
-    credits: {
-      enabled: false,
-    },
-    title: null,
-    xAxis: {
-      dateTimeLabelFormats: { year: "%Y" },
-      type: "datetime",
-    },
-    yAxis: {
-      title: yaxisLabel,
-      min: 0,
-    },
-    plotOptions: {
-      line: {
-        animation: false,
+      chart: {
+          renderTo: el,
+          type: "column",
+          marginRight: 10,
+          marginBottom: 25
       },
-      series: {
-        point: {
-          events: {
-            click: function () {
-              var date = moment.utc(new Date(this.x)).format("YYYY-MM-DD");
-              window.location.href = "/donations?date=" + date;
-            },
-          },
-        },
-        marker: {
-          fillColor: color,
-          radius: 0,
-          states: {
-            hover: {
-              enabled: true,
-              radius: 5,
-            },
-          },
-        },
-        shadow: false,
-        states: {
-          hover: {
-            lineWidth: 2,
-          },
-        },
+      legend: {
+        backgroundColor: "#ffffff",
+        borderColor: "#cccccc",
+        floating: true,
+        verticalAlign: "top"
       },
-    },
-    tooltip: {
-      crosshairs: true,
-      formatter: function () {
-        var s =
-          "<strong>" +
-          ChartHelper.toolTipDateFormat(pointInterval, this.x) +
-          "</strong>";
-        $.each(this.points, function (i, point) {
-          s +=
-            "<br /><span style='color: " +
-            point.series.color +
-            "'>" +
-            point.series.name +
-            ":</span> $" +
-            Highcharts.numberFormat(point.y, 0, ".", ",");
-        });
-        return s;
+      credits: {
+        enabled: false
       },
-      shared: true,
-    },
-    series: seriesData,
-  });
-};
-
-ChartHelper.netfunds = function (el, title, sourceTxt, yaxisLabel, data) {
-  var color = "#007E85";
-
-  var seriesData = [
-    {
-      color: color,
-      data: data[0],
-      name: "Funds available",
-    },
-    {
-      color: "#DD0000",
-      data: data[1],
-      name: "Debts",
-    },
-  ];
-
-  //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
-  return new Highcharts.Chart({
-    chart: {
-      renderTo: el,
-      type: "area",
-      marginRight: 10,
-      marginBottom: 25,
-    },
-    legend: {
-      backgroundColor: "#ffffff",
-      borderColor: "#cccccc",
-      floating: true,
-      verticalAlign: "top",
-    },
-    credits: {
-      enabled: false,
-    },
-    title: null,
-    xAxis: {
-      dateTimeLabelFormats: { year: "%Y" },
-      type: "datetime",
-    },
-    yAxis: {
       title: null,
-    },
-    plotOptions: {
-      line: {
-        animation: false,
+      xAxis: {
+          dateTimeLabelFormats: { year: "%Y" },
+          type: "datetime"
       },
-      series: {
-        marker: {
-          fillColor: color,
-          radius: 0,
-          states: {
-            hover: {
-              enabled: true,
-              radius: 5,
-            },
-          },
+      yAxis: {
+          title: yaxisLabel,
+          min: 0
+      },
+      plotOptions: {
+        line: {
+          animation: false
         },
-        shadow: false,
+        series: {
+          point: {
+            events: {
+              click: function() {
+                var date = moment.utc(new Date(this.x)).format('YYYY-MM-DD');
+                window.location.href = '/donations?date=' + date;
+              }
+            }
+          },
+          marker: {
+            fillColor: color,
+            radius: 0,
+            states: {
+              hover: {
+                enabled: true,
+                radius: 5
+              }
+            }
+          },
+          shadow: false,
+          states: {
+             hover: {
+                lineWidth: 2
+             }
+          }
+        }
       },
-    },
-    tooltip: {
-      crosshairs: true,
-      formatter: function () {
-        var s =
-          "<strong>" +
-          ChartHelper.toolTipDateFormat("day", this.x) +
-          "</strong>";
-        $.each(this.points, function (i, point) {
-          s +=
-            "<br /><span style='color: " +
-            point.series.color +
-            "'>" +
-            point.series.name +
-            ":</span> $" +
-            Highcharts.numberFormat(point.y, 0, ".", ",");
-        });
-        return s;
+      tooltip: {
+          crosshairs: true,
+          formatter: function() {
+            var s = "<strong>" + ChartHelper.toolTipDateFormat(pointInterval, this.x) + "</strong>";
+            $.each(this.points, function(i, point) {
+              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
+            });
+            return s;
+          },
+          shared: true
       },
-      shared: true,
-    },
-    series: seriesData,
-  });
-};
+      series: seriesData
+    });
+  }
 
-ChartHelper.donation_expenditure = function (
-  el,
-  title,
-  sourceTxt,
-  yaxisLabel,
-  data
-) {
-  var color = "#007E85";
+ChartHelper.netfunds = function(el, title, sourceTxt, yaxisLabel, data) {
+  var color = '#007E85';
 
-  var seriesData = [
-    {
-      color: color,
-      data: data[0],
-      name: "Donations and loans",
-    },
-    {
-      color: "#DD0000",
-      data: data[1],
-      name: "Expenditures",
-    },
-  ];
+  var seriesData = [{
+          color: color,
+          data: data[0],
+          name: "Funds available"
+        },{
+          color: "#DD0000",
+          data: data[1],
+          name: "Debts"
+        }
+      ]
 
   //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
   return new Highcharts.Chart({
-    chart: {
-      renderTo: el,
-      type: "area",
-      marginRight: 10,
-      marginBottom: 25,
-    },
-    legend: {
-      backgroundColor: "#ffffff",
-      borderColor: "#cccccc",
-      floating: true,
-      verticalAlign: "top",
-    },
-    credits: {
-      enabled: false,
-    },
-    title: null,
-    xAxis: {
-      dateTimeLabelFormats: { year: "%Y" },
-      type: "datetime",
-    },
-    yAxis: {
+      chart: {
+          renderTo: el,
+          type: "area",
+          marginRight: 10,
+          marginBottom: 25
+      },
+      legend: {
+        backgroundColor: "#ffffff",
+        borderColor: "#cccccc",
+        floating: true,
+        verticalAlign: "top"
+      },
+      credits: {
+        enabled: false
+      },
       title: null,
-    },
-    plotOptions: {
-      line: {
-        animation: false,
+      xAxis: {
+          dateTimeLabelFormats: { year: "%Y" },
+          type: "datetime"
       },
-      series: {
-        marker: {
-          fillColor: color,
-          radius: 0,
-          states: {
-            hover: {
-              enabled: true,
-              radius: 5,
-            },
-          },
+      yAxis: {
+          title: null
+      },
+      plotOptions: {
+        line: {
+          animation: false
         },
-        shadow: false,
+        series: {
+          marker: {
+            fillColor: color,
+            radius: 0,
+            states: {
+              hover: {
+                enabled: true,
+                radius: 5
+              }
+            }
+          },
+          shadow: false
+        }
       },
-    },
-    tooltip: {
-      crosshairs: true,
-      formatter: function () {
-        var s =
-          "<strong>" +
-          ChartHelper.toolTipDateFormat("month", this.x) +
-          "</strong>";
-        $.each(this.points, function (i, point) {
-          s +=
-            "<br /><span style='color: " +
-            point.series.color +
-            "'>" +
-            point.series.name +
-            ":</span> $" +
-            Highcharts.numberFormat(point.y, 0, ".", ",");
-        });
-        return s;
+      tooltip: {
+          crosshairs: true,
+          formatter: function() {
+            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
+            $.each(this.points, function(i, point) {
+              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
+            });
+            return s;
+          },
+          shared: true
       },
-      shared: true,
-    },
-    series: seriesData,
-  });
-};
+      series: seriesData
+    });
+  }
 
-ChartHelper.smallDonationExpend = function (el, min_max, data) {
+ChartHelper.donation_expenditure = function(el, title, sourceTxt, yaxisLabel, data) {
+  var color = '#007E85';
+
+  var seriesData = [{
+          color: color,
+          data: data[0],
+          name: "Donations and loans"
+        },{
+          color: "#DD0000",
+          data: data[1],
+          name: "Expenditures"
+        }
+      ]
+
+  //$("#charts").append("<div class='chart' id='chart_grouping_" + iteration + "'></div>")
+  return new Highcharts.Chart({
+      chart: {
+          renderTo: el,
+          type: "area",
+          marginRight: 10,
+          marginBottom: 25
+      },
+      legend: {
+        backgroundColor: "#ffffff",
+        borderColor: "#cccccc",
+        floating: true,
+        verticalAlign: "top"
+      },
+      credits: {
+        enabled: false
+      },
+      title: null,
+      xAxis: {
+          dateTimeLabelFormats: { year: "%Y" },
+          type: "datetime"
+      },
+      yAxis: {
+          title: null
+      },
+      plotOptions: {
+        line: {
+          animation: false
+        },
+        series: {
+          marker: {
+            fillColor: color,
+            radius: 0,
+            states: {
+              hover: {
+                enabled: true,
+                radius: 5
+              }
+            }
+          },
+          shadow: false
+        }
+      },
+      tooltip: {
+          crosshairs: true,
+          formatter: function() {
+            var s = "<strong>" + ChartHelper.toolTipDateFormat("month", this.x) + "</strong>";
+            $.each(this.points, function(i, point) {
+              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
+            });
+            return s;
+          },
+          shared: true
+      },
+      series: seriesData
+    });
+  }
+
+ChartHelper.smallDonationExpend = function(el, min_max, data) {
   var min = min_max[0];
   var max = min_max[1];
-  var color = "#007E85";
+  var color = '#007E85';
 
-  var seriesData = [
-    {
-      color: color,
-      data: data[0],
-      name: "Donations",
-    },
-    {
-      color: "#DD0000",
-      data: data[1],
-      name: "Expenditures",
-    },
-  ];
+  var seriesData = [{
+          color: color,
+          data: data[0],
+          name: "Donations"
+        },{
+          color: "#DD0000",
+          data: data[1],
+          name: "Expenditures"
+        }
+      ]
 
   return new Highcharts.Chart({
-    chart: {
-      renderTo: el,
-      type: "area",
-      marginRight: 10,
-      marginBottom: 25,
-      backgroundColor: null,
-      height: 100,
-    },
-    legend: {
-      enabled: false,
-    },
-    credits: {
-      enabled: false,
-    },
-    title: null,
-    xAxis: {
-      dateTimeLabelFormats: { year: "%Y" },
-      type: "datetime",
-    },
-    yAxis: {
-      title: null,
-      max: max,
-      min: min,
-    },
-    plotOptions: {
-      line: {
-        animation: false,
+      chart: {
+          renderTo: el,
+          type: "area",
+          marginRight: 10,
+          marginBottom: 25,
+          backgroundColor: null,
+          height: 100,
       },
-      series: {
-        marker: {
-          fillColor: color,
-          radius: 0,
-          states: {
-            hover: {
-              enabled: true,
-              radius: 5,
-            },
+      legend: {
+        enabled: false
+      },
+      credits: {
+        enabled: false
+      },
+      title: null,
+      xAxis: {
+          dateTimeLabelFormats: { year: "%Y" },
+          type: "datetime"
+      },
+      yAxis: {
+          title: null,
+          max: max,
+          min: min
+      },
+      plotOptions: {
+        line: {
+          animation: false
+        },
+        series: {
+          marker: {
+            fillColor: color,
+            radius: 0,
+            states: {
+              hover: {
+                enabled: true,
+                radius: 5
+              }
+            }
           },
-        },
-        shadow: false,
+          shadow: false
+        }
       },
-    },
-    tooltip: {
-      crosshairs: true,
-      formatter: function () {
-        var s =
-          "<strong>" +
-          ChartHelper.toolTipDateFormat("day", this.x) +
-          "</strong>";
-        $.each(this.points, function (i, point) {
-          s +=
-            "<br /><span style='color: " +
-            point.series.color +
-            "'>" +
-            point.series.name +
-            ":</span> $" +
-            Highcharts.numberFormat(point.y, 0, ".", ",");
-        });
-        return s;
-      },
-      shared: true,
-    },
-    series: seriesData,
-  });
-};
-
-ChartHelper.initQualityChart = function (el) {
-  $("#" + el).highcharts({
-    chart: {
-      type: "bar",
-    },
-    credits: {
-      enabled: false,
-    },
-    title: {
-      text: null,
-    },
-    xAxis: {
-      title: null,
-      labels: {
-        enabled: false,
-      },
-    },
-    yAxis: {
-      title: null,
-      min: 1989,
-      max: 2015,
-      labels: {
-        formatter: function () {
-          return parseInt(this.value);
-        },
-      },
-    },
-    plotOptions: {
-      series: {
-        stacking: "true",
-        events: {
-          legendItemClick: function () {
-            return false;
+      tooltip: {
+          crosshairs: true,
+          formatter: function() {
+            var s = "<strong>" + ChartHelper.toolTipDateFormat("day", this.x) + "</strong>";
+            $.each(this.points, function(i, point) {
+              s += "<br /><span style='color: " + point.series.color + "'>" + point.series.name + ":</span> $" + Highcharts.numberFormat(point.y, 0, '.', ',');
+            });
+            return s;
           },
-        },
+          shared: true
       },
-    },
-    tooltip: {
-      borderColor: "#ccc",
-      formatter: function () {
-        return this.series.name;
-      },
-    },
-    legend: { reversed: true },
-    series: [
-      {
-        name: "2000 on: Electronic filings",
-        data: [15],
-        color: "#43ac6a",
-      },
-      {
-        name: "1999: Incomplete",
-        data: [1],
-        color: "#d9edf7",
-      },
-      {
-        name: "1994 - 1999: Manually entered",
-        data: [5],
-        color: "#43ac6a",
-      },
-      {
-        name: "1989 - 1994: Bad entries",
-        data: [1994],
-        color: "#d9edf7",
-      },
-    ],
+      series: seriesData
   });
-};
+}
 
-ChartHelper.pointInterval = function (interval) {
-  if (interval == "year") return 365 * 24 * 3600 * 1000;
-  if (interval == "quarter") return 3 * 30.4 * 24 * 3600 * 1000;
-  if (interval == "month")
-    //this is very hacky. months have different day counts, so our point interval is the average - 30.4
+ChartHelper.initQualityChart = function(el) {
+  $('#' + el).highcharts({
+      chart: {
+          type: 'bar'
+      },
+      credits: {
+        enabled: false
+      },
+      title: {
+          text: null
+      },
+      xAxis: {
+        title: null,
+          labels: {
+            enabled: false
+          }
+      },
+      yAxis:{
+          title: null,
+          min: 1989,
+          max: 2015,
+          labels: {
+            formatter: function() { return parseInt(this.value); }
+          }
+      },
+      plotOptions: {
+          series: {
+              stacking: 'true',
+              events: {
+                legendItemClick: function () {
+                  return false;
+              }
+            }
+          }
+      },
+      tooltip: {
+        borderColor: "#ccc",
+        formatter: function() {
+          return this.series.name;
+        }
+      },
+      legend: { reversed: true },
+      series: [
+        {
+          name: '2000 on: Electronic filings',
+          data: [ 15 ],
+          color: "#43ac6a",
+        },
+        {
+          name: '1999: Incomplete',
+          data: [ 1 ],
+          color: "#d9edf7"
+        },
+        {
+          name: '1994 - 1999: Manually entered',
+          data: [ 5 ],
+          color: "#43ac6a"
+        },
+        {
+          name: '1989 - 1994: Bad entries',
+          data: [ 1994 ],
+          color: "#d9edf7"
+        }
+      ]
+  });
+}
+
+ChartHelper.pointInterval = function(interval) {
+  if (interval == "year")
+    return 365 * 24 * 3600 * 1000;
+  if (interval == "quarter")
+    return 3 * 30.4 * 24 * 3600 * 1000;
+  if (interval == "month") //this is very hacky. months have different day counts, so our point interval is the average - 30.4
     return 30.4 * 24 * 3600 * 1000;
-  if (interval == "week") return 7 * 24 * 3600 * 1000;
-  if (interval == "day") return 24 * 3600 * 1000;
-  if (interval == "hour") return 3600 * 1000;
-  else return 1;
-};
+  if (interval == "week")
+    return 7 * 24 * 3600 * 1000;
+  if (interval == "day")
+    return 24 * 3600 * 1000;
+  if (interval == "hour")
+    return 3600 * 1000;
+  else
+    return 1;
+}
 
-ChartHelper.toolTipDateFormat = function (interval, x) {
-  if (interval == "year") return Highcharts.dateFormat("%Y", x);
-  if (interval == "quarter") return Highcharts.dateFormat("%B %Y", x);
-  if (interval == "month") return Highcharts.dateFormat("%B %Y", x);
-  if (interval == "week") return Highcharts.dateFormat("%e %b %Y", x);
-  if (interval == "day") return Highcharts.dateFormat("%e %b %Y", x);
-  if (interval == "hour") return Highcharts.dateFormat("%H:00", x);
-  else return 1;
-};
+ChartHelper.toolTipDateFormat = function(interval, x) {
+  if (interval == "year")
+    return Highcharts.dateFormat("%Y", x);
+  if (interval == "quarter")
+    return Highcharts.dateFormat("%B %Y", x);
+  if (interval == "month")
+    return Highcharts.dateFormat("%B %Y", x);
+  if (interval == "week")
+    return Highcharts.dateFormat("%e %b %Y", x);
+  if (interval == "day")
+    return Highcharts.dateFormat("%e %b %Y", x);
+  if (interval == "hour")
+    return Highcharts.dateFormat("%H:00", x);
+  else
+    return 1;
+}
 
 // x is difference between beginning and end of reporting period in weeks (can be a float)
 // y amount contributed within period / x
-ChartHelper.generateSeriesData = function (listOfData) {
-  var sumX = 0.0;
-  for (var i = 0; i < listOfData.length; i++) {
-    sumX += listOfData[i].x;
-  }
-  var gap = (sumX / listOfData.length) * 0.2;
-  var allSeries = [];
-  var x = 0.0;
-  for (var i = 0; i < listOfData.length; i++) {
-    var data = listOfData[i];
-    allSeries[i] = {
-      name: data.name,
-      data: [
-        [x, 0],
-        [x, data.y],
-        {
-          x: x + data.x / 2.0,
-          y: data.y,
-          // dataLabels: { enabled: true, format: data.x + ' x {y}' }
-        },
-        [x + data.x, data.y],
-        [x + data.x, 0],
-      ],
-      w: data.x,
-      h: data.y,
-    };
-    x += data.x + gap;
-  }
-  return allSeries;
-};
+ChartHelper.generateSeriesData = function(listOfData) {
+    var sumX = 0.0;
+    for (var i = 0; i < listOfData.length; i++) {
+        sumX += listOfData[i].x;
+    }
+    var gap = sumX / listOfData.length * 0.2;
+    var allSeries = []
+    var x = 0.0;
+    for (var i = 0; i < listOfData.length; i++) {
+        var data = listOfData[i];
+        allSeries[i] = {
+            name: data.name,
+            data: [
+                [x, 0], [x, data.y],
+                {
+                    x: x + data.x / 2.0,
+                    y: data.y
+                    // dataLabels: { enabled: true, format: data.x + ' x {y}' }
+                },
+                [x + data.x, data.y], [x + data.x, 0]
+            ],
+            w: data.x,
+            h: data.y
+        };
+        x += data.x + gap;
+    }
+    return allSeries;
+}

--- a/camp_fin/templates/base-detail.html
+++ b/camp_fin/templates/base-detail.html
@@ -260,7 +260,7 @@
       debt_trend_f.push([Date.UTC(debt_trend[i][1],debt_trend[i][2]-1,debt_trend[i][3]), debt_trend[i][0]]);
     }
 
-    ChartHelper.netfunds('net-funds-chart', 'Net funds over time', '', 'Funds', [balance_trend_f, debt_trend_f]);
+    ChartHelper.netfunds('net-funds-chart', 'Funds available and debts by filing date', '', 'Funds available / Debts', [balance_trend_f, debt_trend_f], balance_trend[0][1], balance_trend[balance_trend.length - 1][1]);
 
 
     //render donation/expenditure chart
@@ -280,7 +280,7 @@
       expend_trend_f.push([Date.UTC(expend_trend[i][1],expend_trend[i][2]-1,expend_trend[i][3]), expend_trend[i][0]]);
     }
 
-    ChartHelper.donation_expenditure('expend-chart', 'Donations and expenditures over time', '', 'Money', [donation_trend_f, expend_trend_f]);
+    ChartHelper.donation_expenditure('expend-chart', 'Contributions and expenditures by month', '', 'Contributions / Expenditures', [donation_trend_f, expend_trend_f], donation_trend[0][1], donation_trend[donation_trend.length - 1][1]);
   </script>
   <script type="text/javascript">
     function getPersonName(object){

--- a/camp_fin/templates/base-detail.html
+++ b/camp_fin/templates/base-detail.html
@@ -245,42 +245,62 @@
     }
 
     //render net balance chart
-    var balance_trend = {{balance_trend}};
+    var balance_trend = {{balance_trend|safe}};
     var balance_trend_f = [];
-    var debt_trend = {{debt_trend}};
+
+    var debt_trend = {{debt_trend|safe}};
     var debt_trend_f = [];
 
-    // format balances
-    for (i = 0; i < balance_trend.length; i++) {
-      balance_trend_f.push([Date.UTC(balance_trend[i][1],balance_trend[i][2]-1,balance_trend[i][3]), balance_trend[i][0]]);
-    }
-
-    // format debt
-    for (i = 0; i < debt_trend.length; i++) {
-      debt_trend_f.push([Date.UTC(debt_trend[i][1],debt_trend[i][2]-1,debt_trend[i][3]), debt_trend[i][0]]);
-    }
-
-    ChartHelper.netfunds('net-funds-chart', 'Funds available and debts by filing date', '', 'Funds available / Debts', [balance_trend_f, debt_trend_f], balance_trend[0][1], balance_trend[balance_trend.length - 1][1]);
-
-
-    //render donation/expenditure chart
-    var expend_trend = {{expend_trend}};
+    var expend_trend = {{expend_trend|safe}};
     var expend_trend_f = [];
 
-    var donation_trend = {{donation_trend}};
+    var donation_trend = {{donation_trend|safe}};
     var donation_trend_f = [];
 
-    // format donations
-    for (i = 0; i < donation_trend.length; i++) {
-      donation_trend_f.push([Date.UTC(donation_trend[i][1],donation_trend[i][2]-1,donation_trend[i][3]), donation_trend[i][0]]);
-    }
+    balance_trend.forEach(function(bal) {
+      balance_trend_f.push({
+        y: bal.amount,
+        x: Date.UTC(bal.year, bal.month-1, bal.day),
+        description: bal.description,
+      })
+    })
 
-    // format expenditures
-    for (i = 0; i < expend_trend.length; i++) {
-      expend_trend_f.push([Date.UTC(expend_trend[i][1],expend_trend[i][2]-1,expend_trend[i][3]), expend_trend[i][0]]);
-    }
+    debt_trend.forEach(function(debt) {
+      debt_trend_f.push({
+        y: debt.amount,
+        x: Date.UTC(debt.year, debt.month-1, debt.day),
+        description: debt.description,
+      })
+    })
 
-    ChartHelper.donation_expenditure('expend-chart', 'Contributions and expenditures by month', '', 'Contributions / Expenditures', [donation_trend_f, expend_trend_f], donation_trend[0][1], donation_trend[donation_trend.length - 1][1]);
+    expend_trend.forEach(function(exp) {
+      expend_trend_f.push({
+        y: exp.amount,
+        x: Date.UTC(exp.year, exp.month-1),
+      })
+    })
+
+    donation_trend.forEach(function(don) {
+      donation_trend_f.push({
+        y: don.amount,
+        x: Date.UTC(don.year, don.month-1),
+        description: don.description,
+      })
+    })
+
+    const chartValues = Array.prototype.concat(balance_trend, debt_trend, expend_trend, donation_trend)
+
+    const startYear = chartValues.reduce(function(prev, current) {
+      return (prev && prev.year > current.year) ? current : prev
+    }).year
+
+    const endYear = chartValues.reduce(function(prev, current) {
+      return (prev && prev.year > current.year) ? prev : current
+    }).year
+
+    ChartHelper.netfunds('net-funds-chart', 'Funds available and debts by filing period', '', 'Funds available / Debts', [balance_trend_f, debt_trend_f], startYear, endYear);
+
+    ChartHelper.donation_expenditure('expend-chart', 'Contributions and expenditures by month', '', 'Contributions / Expenditures', [donation_trend_f, expend_trend_f], startYear, endYear);
   </script>
   <script type="text/javascript">
     function getPersonName(object){

--- a/camp_fin/templates/camp_fin/candidate-detail.html
+++ b/camp_fin/templates/camp_fin/candidate-detail.html
@@ -83,7 +83,7 @@
 {% endblock %}
 
 {% block charts %}
-  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing period</h3>
+  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing</h3>
   <div id='net-funds-chart'></div>
 
   <h3><i class="fa fa-fw fa-bar-chart"></i> Contributions and expenditures by month</h3>

--- a/camp_fin/templates/camp_fin/candidate-detail.html
+++ b/camp_fin/templates/camp_fin/candidate-detail.html
@@ -83,7 +83,7 @@
 {% endblock %}
 
 {% block charts %}
-  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing date</h3>
+  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing period</h3>
   <div id='net-funds-chart'></div>
 
   <h3><i class="fa fa-fw fa-bar-chart"></i> Contributions and expenditures by month</h3>

--- a/camp_fin/templates/camp_fin/candidate-detail.html
+++ b/camp_fin/templates/camp_fin/candidate-detail.html
@@ -83,10 +83,10 @@
 {% endblock %}
 
 {% block charts %}
-  <h3><i class="fa fa-fw fa-area-chart"></i> Net funds over time</h3>
+  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing date</h3>
   <div id='net-funds-chart'></div>
 
-  <h3><i class="fa fa-fw fa-bar-chart"></i> Donations and expenditures over time</h3>
+  <h3><i class="fa fa-fw fa-bar-chart"></i> Contributions and expenditures by month</h3>
   <div id='expend-chart'></div>
 
 {% endblock %}

--- a/camp_fin/templates/camp_fin/committee-detail.html
+++ b/camp_fin/templates/camp_fin/committee-detail.html
@@ -36,7 +36,7 @@
   </div>
 {% endblock %}
 {% block charts %}
-  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing period</h3>
+  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing</h3>
   <div id='net-funds-chart'></div>
 
   <h3><i class="fa fa-fw fa-bar-chart"></i> Contributions and expenditures by month</h3>

--- a/camp_fin/templates/camp_fin/committee-detail.html
+++ b/camp_fin/templates/camp_fin/committee-detail.html
@@ -36,10 +36,10 @@
   </div>
 {% endblock %}
 {% block charts %}
-  <h3>Net funds over time</h3>
+  <h3><i class="fa fa-fw fa-area-chart"></i> Funds available and debts by filing period</h3>
   <div id='net-funds-chart'></div>
 
-  <h3>Donations and expenditures over time</h3>
+  <h3><i class="fa fa-fw fa-bar-chart"></i> Contributions and expenditures by month</h3>
   <div id='expend-chart'></div>
 {% endblock %}
 


### PR DESCRIPTION
## Overview

This PR updates the charts on candidate and committee pages. Namely it:

- Changes them from area charts to step charts, see https://github.com/datamade/openness-project-nmid/pull/216#issuecomment-2386614376
- Updates chart titles, adds axis labels
- Forces a consistent date range along the x-axis for easier comparison, see https://github.com/datamade/openness-project-nmid/pull/216#issuecomment-2389141748
- Fixes tooltip formatting
- Updates the available funds chart to use the end of the filing period, rather than the date the filing was made

It also updates the aggregate queries to force a continuous interval of aggregate data. Previously, it was sparse, which posed a challenge for charting. See https://github.com/datamade/openness-project-nmid/pull/216#discussion_r1786566219

### Demo

![charts](https://github.com/user-attachments/assets/3f4ff7b7-6298-4347-8c00-85b568b51422)

## Testing instructions

Update your local Docker Compose file to connect to a read-only version of the prod database (see Money Trail NM - Docker Env - Readonly Prod DB note in Bitwarden), then view some donation / expenditure charts and confirm they look good.
