### PR TITLE
Add link to independent expenditure excel file

### DIFF
--- a/pages/templates/downloads.html
+++ b/pages/templates/downloads.html
@@ -67,8 +67,23 @@
             <br/><br />
           </div>
         </div>
+
+				<div class="row mb-3">
+					<h3>
+						<i class="fa fa-table"></i>
+						Independent Expenditures
+					</h3>
+					<a href="https://openness-project-nmid.s3.amazonaws.com/independent_expenditures.xlsx" target="_blank">
+						Download Independent Expenditures Spreadsheet
+					</a>
+          <div class="col-xs-12">
+            <br/><br />
+          </div>
+				</div>
+
       </div>
     </div>
+
   </div>
 {% endblock %}
 

--- a/pages/templates/downloads.html
+++ b/pages/templates/downloads.html
@@ -68,18 +68,18 @@
           </div>
         </div>
 
-				<div class="row mb-3">
-					<h3>
-						<i class="fa fa-table"></i>
-						Independent Expenditures
-					</h3>
-					<a href="https://openness-project-nmid.s3.amazonaws.com/independent_expenditures.xlsx" target="_blank">
-						Download Independent Expenditures Spreadsheet
-					</a>
+        <div class="row mb-3">
+          <h3>
+            <i class="fa fa-table"></i>
+            Independent Expenditures
+          </h3>
+          <a href="https://openness-project-nmid.s3.amazonaws.com/independent_expenditures.xlsx" target="_blank">
+            Download Independent Expenditures Spreadsheet
+          </a>
           <div class="col-xs-12">
             <br/><br />
           </div>
-				</div>
+        </div>
 
       </div>
     </div>


### PR DESCRIPTION
## Overview

This PR adds a link to an excel file of scraped independent expenditures to the download page.

Closes #211 

### Demo

<img width="447" alt="Screenshot 2024-10-02 at 12 10 01 PM" src="https://github.com/user-attachments/assets/64379cb7-e951-40ba-9102-2f1298e4dc0d">

## Testing Instructions

* Verify that the new link works on the download page
