### PR TITLE
Update lobbyist data links

### DIFF
--- a/pages/templates/downloads.html
+++ b/pages/templates/downloads.html
@@ -83,11 +83,11 @@
 
         <div class="row mb-3">
           <h3>
-            <i class="fa fa-file"></i>
+            <i class="fa fa-table"></i>
             Lobbyist Employer
           </h3>
-          <a href="https://openness-project-nmid.s3.amazonaws.com/lobbyist_employer.csv" target="_blank">
-            Download Lobbyist Employer Data
+          <a href="https://openness-project-nmid.s3.amazonaws.com/lobbyist_employer.xlsx" target="_blank">
+            Download Lobbyist Employer Spreadsheet
           </a>
           <div class="col-xs-12">
             <br/><br />
@@ -96,11 +96,11 @@
 
         <div class="row mb-3">
           <h3>
-            <i class="fa fa-file"></i>
+            <i class="fa fa-table"></i>
             Lobbyist
           </h3>
-          <a href="https://openness-project-nmid.s3.amazonaws.com/lobbyists.csv" target="_blank">
-            Download Lobbyist Data
+          <a href="https://openness-project-nmid.s3.amazonaws.com/lobbyist.xlsx" target="_blank">
+            Download Lobbyist Spreadsheet
           </a>
           <div class="col-xs-12">
             <br/><br />


### PR DESCRIPTION
## Overview

This PR updates lobbyist data links to the new excel sheets on S3.

### Demo

<img width="461" alt="Screenshot 2024-10-10 at 3 04 09 PM" src="https://github.com/user-attachments/assets/18cf96ee-6e7c-4361-b7eb-a444c4bd76bf">


## Testing Instructions

* Verify that the new links work
